### PR TITLE
Streaming 4player

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ To run split screen correctly, you need to modify Unreal Engine. Go to GameViewp
 
 ## Usage
 Split screen is now working. You will need to join game in the official way with CloudyPanel. For convenience, I have included my testing file OtherFiles/sendTCP.py, which you can use to join game. Plugin streams to HTTP, so use VLC to catch the frames. The addresses are:
+
 ControllerId 1: http://localhost:8080,
+
 ControllerId 2: http://localhost:8081
+
 ControllerId 3: http://localhost:8082
+
 ControllerId 4: http://localhost:8083
+
 
 Note, all files from ffmpeg (output video, sdp file, log file out.txt etc) are probably generated in your Unreal Engine\Engine\Binaries\Win64 folder.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ To run split screen correctly, you need to modify Unreal Engine. Go to GameViewp
 
 ## Usage
 Split screen is now working. You will need to join game in the official way with CloudyPanel. For convenience, I have included my testing file OtherFiles/sendTCP.py, which you can use to join game. Plugin streams to HTTP, so use VLC to catch the frames. The addresses are:
-Player 1: http://localhost:8080,
-Player 2: http://localhost:8081
-Player 3: http://localhost:8082
-Player 4: http://localhost:8083
+ControllerId 1: http://localhost:8080,
+ControllerId 2: http://localhost:8081
+ControllerId 3: http://localhost:8082
+ControllerId 4: http://localhost:8083
 
 Note, all files from ffmpeg (output video, sdp file, log file out.txt etc) are probably generated in your Unreal Engine\Engine\Binaries\Win64 folder.

--- a/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
+++ b/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
@@ -68,7 +68,7 @@ public:
 	FString CCloudyPanelPluginModule::StringFromBinaryArray(const TArray<uint8>& BinaryArray);
 
 	/** Video Capture*/
-	void CCloudyPanelPluginModule::SetUpVideoCapture();
+	void CCloudyPanelPluginModule::SetUpVideoCapture(int ControllerId);
 	void CCloudyPanelPluginModule::StreamFrameToClient();
 	int CCloudyPanelPluginModule::GetNumberOfPlayers();
 	// Only handle 4 player split screen for current solution
@@ -90,6 +90,7 @@ public:
 	TArray<TArray<FColor> > FrameBufferList;
 	bool isEngineRunning;
 	int sizeX, sizeY;
+	TArray<int> PlayerFrameMapping; // index is frame index, value is player index
 
 	/**
 	* Enum to establish command protocol between CloudyPanel and CloudyPanelPlugin


### PR DESCRIPTION
Handled mapping of controllerid, frame position and port number. Now port number is based on ControllerId, so Thin Client can just read the assigned port according to ControllerId. Quit game now also works, from my tests.
