### PR TITLE
Optimise streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@ To run split screen correctly, you need to modify Unreal Engine. Go to GameViewp
 
 	Comment out this line: const ESplitScreenType::Type SplitType = GetCurrentSplitscreenConfiguration();
 	Add this line: const ESplitScreenType::Type SplitType = ESplitScreenType::FourPlayer;
+	
+Set the IP in the function CCloudyPanelPluginModule::SetUpPlayer before streaming.
 
 ## Usage
-Split screen is now working. You will need to join game in the official way with CloudyPanel. For convenience, I have included my testing file OtherFiles/sendTCP.py, which you can use to join game. Plugin streams to HTTP, so use VLC to catch the frames. The addresses are:
+Split screen is now working. To join game, you can test using OtherFiles/sendTCP.py. Run the file and input 00000001 to add Player 1. More details in the file. Plugin streams to HTTP, so use VLC to catch the frames. The ports are:
 
-ControllerId 1: http://localhost:30000,
+ControllerId 1: <your HTTP IP>:30000,
 
-ControllerId 2: http://localhost:30001
+ControllerId 2: <your HTTP IP>:30001
 
-ControllerId 3: http://localhost:30002
+ControllerId 3: <your HTTP IP>:30002
 
-ControllerId 4: http://localhost:30003
+ControllerId 4: <your HTTP IP>:30003
 
 
 Note, all files from ffmpeg (output video, sdp file, log file out.txt etc) are probably generated in your Unreal Engine\Engine\Binaries\Win64 folder.

--- a/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
+++ b/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
@@ -68,7 +68,8 @@ public:
 	FString CCloudyPanelPluginModule::StringFromBinaryArray(const TArray<uint8>& BinaryArray);
 
 	/** Video Capture*/
-	void CCloudyPanelPluginModule::SetUpVideoCapture(int ControllerId);
+	void CCloudyPanelPluginModule::SetUpVideoCapture();
+	void CCloudyPanelPluginModule::SetUpPlayer(int ControllerId);
 	void CCloudyPanelPluginModule::StreamFrameToClient();
 	// Only handle 4 player split screen for current solution
 	void CCloudyPanelPluginModule::Split4Player();
@@ -88,6 +89,8 @@ public:
 	bool isEngineRunning;
 	int sizeX, sizeY, halfSizeX, halfSizeY;
 	TArray<int> PlayerFrameMapping; // index is frame index, value is player index
+	FIntRect Screen1, Screen2, Screen3, Screen4;
+	FReadSurfaceDataFlags flags;
 
 	/**
 	* Enum to establish command protocol between CloudyPanel and CloudyPanelPlugin

--- a/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
+++ b/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
@@ -72,7 +72,7 @@ public:
 	void CCloudyPanelPluginModule::StreamFrameToClient();
 	int CCloudyPanelPluginModule::GetNumberOfPlayers();
 	// Only handle 4 player split screen for current solution
-	void CCloudyPanelPluginModule::Split4Player(TArray<FColor> FrameBuffer, int FrameOffset);
+	void CCloudyPanelPluginModule::Split4Player();
 
 
 	/** Class Variables */

--- a/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
+++ b/Source/CloudyPanelPlugin/Public/CloudyPanelPlugin.h
@@ -70,7 +70,6 @@ public:
 	/** Video Capture*/
 	void CCloudyPanelPluginModule::SetUpVideoCapture(int ControllerId);
 	void CCloudyPanelPluginModule::StreamFrameToClient();
-	int CCloudyPanelPluginModule::GetNumberOfPlayers();
 	// Only handle 4 player split screen for current solution
 	void CCloudyPanelPluginModule::Split4Player();
 
@@ -84,12 +83,10 @@ public:
 
 	// For Video capture
 	int NumberOfPlayers;
-	int FrameOffset; // offset for reading frame when frame height is odd
 	TArray<FILE*> VideoPipeList;
-	TArray<FColor> FrameBuffer;
 	TArray<TArray<FColor> > FrameBufferList;
 	bool isEngineRunning;
-	int sizeX, sizeY;
+	int sizeX, sizeY, halfSizeX, halfSizeY;
 	TArray<int> PlayerFrameMapping; // index is frame index, value is player index
 
 	/**


### PR DESCRIPTION
Streaming has been optimised with the following changes:
- Some calculations have been changed to variables to reduce calculation and function calls: frame height and width, frame buffer size
- Split screen implementation has changed; calling a subset of pixels from viewport instead of splitting pixels manually
- Declaration of 'new' variable brought out of loop
- Bit shifting is used instead of multiplication in converting pixels to bytes
