### PR TITLE
Load game safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ virtual bool Cloudy_SaveGameToSlot
     const int32 PCID, // Player Controller ID of the player you are saving
 )
 ```
+`Cloudy_LoadGameFromSlot` takes in the same three functions as Unreal Engine's `LoadGameFromSlot`, with an additional parameter: the player controller index.
+
+API:
+```cpp
+UFUNCTION(BlueprintCallable, Category="Game")
+USaveGame* Cloudy_LoadGameFromSlot
+(
+    const FString& SlotName, 
+    const int32 UserIndex,
+    const int32 PCID
+)
+````
+
+Additionally, before loading the data from the save file, please check if the save file has been successfully downloaded from our cloud.
+
+For example:
+```cpp
+UMySaveGame* LoadGameInstance = Cast<UMySaveGame>(UGameplayStatics::CreateSaveGameObject(UMySaveGame::StaticClass()));
+LoadGameInstance = Cast<UMySaveGame>(ICloudySaveManager::Get().Cloudy_LoadGameFromSlot(TEXT("SaveGame1"), 
+                                                                                       LoadGameInstance->UserIndex, 0));
+if (LoadGameInstance != NULL)
+{
+    ...
+    Load your data here
+    ...
+}
+```
 
 Example: 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Module to provide customized save game and load game API. This API will allow th
   - Ensure that `#include "ICloudySaveManager.h"` is included.
 
 ## Usage
+### Save Game
 `Cloudy_SaveGameToSlot` takes in the same three functions as Unreal Engine's `SaveGameToSlot`, with an additional parameter: the player controller index.
 
 API:
@@ -74,12 +75,22 @@ API:
 UFUNCTION(BlueprintCallable, Category="Game")
 virtual bool Cloudy_SaveGameToSlot
 (
-    USaveGame * SaveGameObject,
-    const FString & SlotName,
+    USaveGame * SaveGameObject, // The save game object
+    const FString & SlotName,   // The name of the save file
     const int32 UserIndex,
-    const int32 PCID, // Player Controller ID of the player you are saving
+    const int32 PCID,           // Player Controller ID of the player you are saving
 )
 ```
+Example: 
+```cpp
+#include "ICloudySaveManager.h"
+
+// Create a save game object
+UMySaveGame* SaveGameInstance = Cast<UMySaveGame>(UGameplayStatics::CreateSaveGameObject(UMySaveGame::StaticClass()));
+// Save the game, and upload to our cloud
+ICloudySaveManager::Get().Cloudy_SaveGameToSlot(SaveGameInstance, "SaveGame1", SaveGameInstance->UserIndex, 0);
+```
+### Load Game
 `Cloudy_LoadGameFromSlot` takes in the same three functions as Unreal Engine's `LoadGameFromSlot`, with an additional parameter: the player controller index.
 
 API:
@@ -87,9 +98,9 @@ API:
 UFUNCTION(BlueprintCallable, Category="Game")
 USaveGame* Cloudy_LoadGameFromSlot
 (
-    const FString& SlotName, 
+    const FString& SlotName,  // The name of the save file
     const int32 UserIndex,
-    const int32 PCID
+    const int32 PCID          // Player Controller ID of the player you are saving
 )
 ````
 
@@ -97,25 +108,16 @@ Additionally, before loading the data from the save file, please check if the sa
 
 For example:
 ```cpp
+// Create the save game object
 UMySaveGame* LoadGameInstance = Cast<UMySaveGame>(UGameplayStatics::CreateSaveGameObject(UMySaveGame::StaticClass()));
+// Attempt to load the save game from our cloud
 LoadGameInstance = Cast<UMySaveGame>(ICloudySaveManager::Get().Cloudy_LoadGameFromSlot(TEXT("SaveGame1"), 
                                                                                        LoadGameInstance->UserIndex, 0));
+// Check if the save file has been loaded successfully
 if (LoadGameInstance != NULL)
 {
-    ...
-    Load your data here
-    ...
+    //Load your data here
 }
-```
-
-Example: 
-```cpp
-#include "ICloudySaveManager.h"
-
-// Create a save game object
-UMySaveGame* SaveGameInstance = Cast<UMySaveGame>(UGameplayStatics::CreateSaveGameObject(UMySaveGame::StaticClass()));
-// Save the game
-ICloudySaveManager::Get().Cloudy_SaveGameToSlot(SaveGameInstance, "SaveGame1", SaveGameInstance->UserIndex, 0);
 ```
 
 # CloudyWebAPI

--- a/Source/CloudyWebAPI/Private/CloudyWebAPI.cpp
+++ b/Source/CloudyWebAPI/Private/CloudyWebAPI.cpp
@@ -418,7 +418,7 @@ void CloudyWebAPIImpl::ReadAndStoreSaveFileURL(FString JsonString, int32 PlayerC
     // More player controllers than the TArray size
     if (PlayerControllerId >= SaveFileUrls.Num())
     {
-        SaveFileUrls.AddUninitialized(PlayerControllerId - InitialArraySize + 1);
+        SaveFileUrls.AddUninitialized(PlayerControllerId - SaveFileUrls.Num() + 1);
     }
     if (JsonObject->HasField("saved_file"))
     {


### PR DESCRIPTION
Loading game has to be checked for safety by the game developer in their game. The default `LoadGameFromSlot` function by Unreal Engine always returns a `SaveGameObject`, so I try to keep it the same. A NULL `SaveGameObject` will be returned if the game did not load the game from CloudyWeb.

So, the developer should check if the `SaveGameObject` is NULL before using it. I have added this to the readme.
