### PR TITLE
fixed bug: pawn was not destroyed after quitting game

### DIFF
--- a/Source/CloudyPlayerManager/Private/CloudyPlayerManager.cpp
+++ b/Source/CloudyPlayerManager/Private/CloudyPlayerManager.cpp
@@ -86,11 +86,19 @@ bool CCloudyPlayerManagerModule::RemovePlayer(int32 ControllerId, int32 GameSess
 	ULocalPlayer* const ExistingPlayer = GameInstance->FindLocalPlayerFromControllerId(ControllerId);
 	bool Success = false;
 
+
+	
+	
+	
+
+
 	if (ExistingPlayer != NULL)
 	{
 		UE_LOG(ModuleLog, Warning, TEXT("Controller Id: %d"), ControllerId);
 
-		// Future implementation of Quit Game - delete session from server
+		// destroy the quitting player's pawn
+		APlayerController* Controller = ExistingPlayer->PlayerController;
+		Controller->GetPawn()->Destroy();
 
 		// delete appropriate game session
 		int32 GameSessionId = GameSessionIdMapping[ControllerId];

--- a/Source/CloudyStream/Private/CloudyStream.cpp
+++ b/Source/CloudyStream/Private/CloudyStream.cpp
@@ -79,7 +79,13 @@ bool CloudyStreamImpl::CaptureFrame(float DeltaTime) {
 		SetUpVideoCapture();
 		UGameInstance* GameInstance = GEngine->GameViewport->GetGameInstance();
 		NumberOfPlayers = 0;
+		
+		ULocalPlayer* const ExistingPlayer = GameInstance->FindLocalPlayerFromControllerId(0);
+		APlayerController* Controller = ExistingPlayer->PlayerController;
+		Controller->GetPawn()->Destroy();
 		GameInstance->DebugRemovePlayer(0); // remove default first player
+
+
 	}
 
 	// engine has been stopped


### PR DESCRIPTION
Originally, after quitting default Player 0, his pawn was still there. Same for quitting other players through Thin Client. Players' pawns have been destroyed accordingly.
